### PR TITLE
Send messages to players that already have interact or are missing nointeract, and teleport players with interact to the alt_spawnpoint

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,9 +22,11 @@ minetest.register_on_chat_message(function(name, message)
 			if minetest.get_modpath("irc") then
 				irc:say(("* %s%s"):format("", "player, "..name.." Read the rules and has been granted interact!"))
 			end
+			minetest.get_player_by_name(name):setpos(minetest.setting_get_pos("alt_spawnpoint"))
 		else
 			if minetest.get_player_privs(name).interact then
 				minetest.chat_send_player(name,"You already have interact! It is only necessary to say the keyword once.")
+				minetest.get_player_by_name(name):setpos(minetest.setting_get_pos("alt_spawnpoint"))
 			else
 				minetest.chat_send_player(name,"You have been prevented from obtaining the interact privilege. Contact a server administrator if you believe this to be in error.")
 			end

--- a/init.lua
+++ b/init.lua
@@ -22,11 +22,11 @@ minetest.register_on_chat_message(function(name, message)
 			if minetest.get_modpath("irc") then
 				irc:say(("* %s%s"):format("", "player, "..name.." Read the rules and has been granted interact!"))
 			end
-			minetest.get_player_by_name(name):setpos(minetest.setting_get_pos("alt_spawnpoint"))
+			if minetest.setting_get_pos("alt_spawnpoint") then minetest.get_player_by_name(name):setpos(minetest.setting_get_pos("alt_spawnpoint")) end
 		else
 			if minetest.get_player_privs(name).interact then
 				minetest.chat_send_player(name,"You already have interact! It is only necessary to say the keyword once.")
-				minetest.get_player_by_name(name):setpos(minetest.setting_get_pos("alt_spawnpoint"))
+				if minetest.setting_get_pos("alt_spawnpoint") then minetest.get_player_by_name(name):setpos(minetest.setting_get_pos("alt_spawnpoint")) end
 			else
 				minetest.chat_send_player(name,"You have been prevented from obtaining the interact privilege. Contact a server administrator if you believe this to be in error.")
 			end

--- a/init.lua
+++ b/init.lua
@@ -8,18 +8,26 @@ local keyword_liveupdate = minetest.setting_getbool("interact_keyword_live_chang
 
 
 minetest.register_on_chat_message(function(name, message)
-	if message == mki_interact_keyword and minetest.get_player_privs(name).nointeract then
-		local privs = minetest.get_player_privs(name)
-			for priv, state in pairs(keyword_privs,privs) do
-				privs[priv] = state
-			end
-			privs.nointeract = nil
-		minetest.set_player_privs(name, privs)
+	if message == mki_interact_keyword then
+		if minetest.get_player_privs(name).nointeract then
+			local privs = minetest.get_player_privs(name)
+				for priv, state in pairs(keyword_privs,privs) do
+					privs[priv] = state
+				end
+				privs.nointeract = nil
+			minetest.set_player_privs(name, privs)
 
-		minetest.chat_send_all("<Server> player, "..name.." Read the rules and has been granted interact!")
-		minetest.log("action", "[autogranter] Player, " .. name .. " Was granted interact for keyword")
-		if minetest.get_modpath("irc") then
-			irc:say(("* %s%s"):format("", "player, "..name.." Read the rules and has been granted interact!"))
+			minetest.chat_send_all("<Server> player, "..name.." Read the rules and has been granted interact!")
+			minetest.log("action", "[autogranter] Player, " .. name .. " Was granted interact for keyword")
+			if minetest.get_modpath("irc") then
+				irc:say(("* %s%s"):format("", "player, "..name.." Read the rules and has been granted interact!"))
+			end
+		else
+			if minetest.get_player_privs(name).interact then
+				minetest.chat_send_player(name,"You already have interact! It is only necessary to say the keyword once.")
+			else
+				minetest.chat_send_player(name,"You have been prevented from obtaining the interact privilege. Contact a server administrator if you believe this to be in error.")
+			end
 		end
 	end
 end)


### PR DESCRIPTION
If a player that says the keyword has nointeract but not interact, it behaves exactly as it did before. If they already have interact, regardless of whether they have nointeract, they will receive a message stating so and that they only need to say the keyword once. If they do not have either, they will receive a message stating that they have been prevented from obtaining interact and should contact an admin if they think it was in error.

Also, players that are granted interact by this mod or already have interact are teleported to the alt_spawnpoint.
